### PR TITLE
IQueryable WhereIf extension method

### DIFF
--- a/src/Spk.Common.Helpers/IEnumerable/WhereIfExtension.cs
+++ b/src/Spk.Common.Helpers/IEnumerable/WhereIfExtension.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Spk.Common.Helpers.IEnumerable
 {
@@ -16,15 +17,20 @@ namespace Spk.Common.Helpers.IEnumerable
             bool condition,
             Func<TSource, bool> predicate)
         {
-            if (condition)
-            {
-                if (source != null)
-                {
-                    return source.Where(predicate);
-                }
-            }
+            return condition && source != null ? source.Where(predicate) : source;
+        }
 
-            return source;
+        /// <summary>
+        ///     Used when data needs to be filtered depending on a condition, using .Where() method.
+        ///     If the condition fails, original source is returned.
+        ///     If the condition pass, filtered source is returned.
+        /// </summary>
+        public static IQueryable<TSource> WhereIf<TSource>(
+            this IQueryable<TSource> source,
+            bool condition,
+            Expression<Func<TSource, bool>> predicate)
+        {
+            return condition && source != null ? source.Where(predicate) : source;
         }
     }
 }

--- a/test/Spk.Common.Tests.Helpers/IEnumerable/WhereIfExtensionTests.cs
+++ b/test/Spk.Common.Tests.Helpers/IEnumerable/WhereIfExtensionTests.cs
@@ -7,43 +7,66 @@ namespace Spk.Common.Tests.Helpers.IEnumerable
 {
     public class WhereIfExtensionTests
     {
-        [Fact]
-        public void WhereIf_ShouldReturn_WhenConditionIsFalse()
+        [InlineData(true)]
+        [InlineData(false)]
+        [Theory]
+        public void WhereIf_ShouldReturn_WhenConditionIsFalse(bool isQueryable)
         {
-            var data = new List<string>
+            // Arrange
+            List<string> data = new List<string>
             {
                 "test",
                 "data",
                 "halleyhop",
                 "blabla"
             };
-            var result = data.WhereIf(false, x => x.Equals("data"));
 
+            // Act
+            IEnumerable<string> result = isQueryable
+                ? data.AsQueryable().WhereIf(false, x => x.Equals("data"))
+                : data.WhereIf(false, x => x.Equals("data"));
+
+            // Assert
             Assert.Equal(4, result.Count());
-            Assert.True(Equals(result, data));
+            Assert.True(result.SequenceEqual(data));
         }
 
-        [Fact]
-        public void WhereIf_ShouldReturn_WhenConditionIsTrue()
+        [InlineData(true)]
+        [InlineData(false)]
+        [Theory]
+        public void WhereIf_ShouldReturn_WhenConditionIsTrue(bool isQueryable)
         {
-            var data = new List<string>
+            // Arrange
+            List<string> data = new List<string>
             {
                 "test",
                 "data",
                 "halleyhop",
                 "blabla"
             };
-            var result = data.WhereIf(data.Count == 4, x => x.Equals("test"));
+
+            // Act
+            IEnumerable<string> result = isQueryable
+                ? data.AsQueryable().WhereIf(data.Count == 4, x => x.Equals("test"))
+                : data.WhereIf(data.Count == 4, x => x.Equals("test"));
+
+            // Assert
             Assert.Single(result);
             Assert.Equal("test", result.First());
         }
 
         [Fact]
-        public void WhereIf_ShouldReturnNull_WhenSourceIsNull()
+        public void WhereIf_ShouldReturnNull_WhenIEnumerableSourceIsNull()
         {
             List<string> data = null;
-            var result = data.WhereIf(true, x => x.Equals("data"));
-            Assert.Null(result);
+            Assert.Null(data.WhereIf(true, x => x.Equals("data")));
+        }
+
+        [Fact]
+        public void WhereIf_ShouldReturnNull_WhenIQueryableSourceIsNull()
+        {
+            IQueryable<string> data = null;
+            Assert.Null(data.WhereIf(true, x => x.Equals("data")));
         }
     }
 }


### PR DESCRIPTION
Unfortunately, doing this without code duplication implicate the use of [expression trees](https://www.codeproject.com/Articles/1241305/LINQ-Part-A-Deep-Dive-Into-a-Queryable-Extension-M). In this particular case, it is a simple one-liner. I think it's somewhat fair.