### PR TITLE
ServiceResult static API to enhance developer experience.

### DIFF
--- a/src/Spk.Common.Helpers/Service/ServiceResult.cs
+++ b/src/Spk.Common.Helpers/Service/ServiceResult.cs
@@ -36,6 +36,23 @@ namespace Spk.Common.Helpers.Service
         {
             return Warnings.FirstOrDefault();
         }
+
+        public static ServiceResult Succeed()
+        {
+            return new ServiceResult();
+        }
+
+        public static ServiceResult Failed(params string[] errors)
+        {
+            var result = new ServiceResult();
+            if (errors != null)
+            {
+                foreach (var error in errors)
+                    result.AddError(error);
+            }
+
+            return result;
+        }
     }
 
     public class ServiceResult<T> : ServiceResult
@@ -54,6 +71,13 @@ namespace Spk.Common.Helpers.Service
         public void SetData(T data)
         {
             Data = data;
+        }
+
+        public static ServiceResult<T> Succeed(T data)
+        {
+            var result = new ServiceResult<T>();
+            result.SetData(data);
+            return result;
         }
     }
 }

--- a/src/Spk.Common.Helpers/Service/ServiceResult.cs
+++ b/src/Spk.Common.Helpers/Service/ServiceResult.cs
@@ -50,7 +50,6 @@ namespace Spk.Common.Helpers.Service
                 foreach (var error in errors)
                     result.AddError(error);
             }
-
             return result;
         }
     }

--- a/src/Spk.Common.Helpers/Service/ServiceResult.cs
+++ b/src/Spk.Common.Helpers/Service/ServiceResult.cs
@@ -75,9 +75,7 @@ namespace Spk.Common.Helpers.Service
 
         public static ServiceResult<T> Succeed(T data)
         {
-            var result = new ServiceResult<T>();
-            result.SetData(data);
-            return result;
+            return new ServiceResult<T>(data);
         }
     }
 }

--- a/test/Spk.Common.Tests.Helpers/Service/ServiceResultTests.cs
+++ b/test/Spk.Common.Tests.Helpers/Service/ServiceResultTests.cs
@@ -135,7 +135,7 @@ namespace Spk.Common.Tests.Helpers.Service
         }
 
         [Fact]
-        public void Errors_ShouldRetriveAllErrors()
+        public void Errors_ShouldRetrieveAllErrors()
         {
             // Arrange
             var sr = new ServiceResult();
@@ -189,7 +189,7 @@ namespace Spk.Common.Tests.Helpers.Service
         }
 
         [Fact]
-        public void Warnings_ShouldRetriveAllWarnings()
+        public void Warnings_ShouldRetrieveAllWarnings()
         {
             // Arrange
             var sr = new ServiceResult();
@@ -202,6 +202,37 @@ namespace Spk.Common.Tests.Helpers.Service
             Assert.Collection(sr.Warnings,
                 x => x.ShouldBe("warning 1"),
                 x => x.ShouldBe("warning 2")
+            );
+        }
+
+        [Fact]
+        public void Succeed_ShouldReturnResultWithSuccess()
+        {
+            // Act && assert
+            ServiceResult.Succeed().Success.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Succeed_ShouldSetData()
+        {
+            // Act
+            var result = ServiceResult<string>.Succeed("result");
+
+            // Act && assert
+            result.Success.ShouldBeTrue();
+            result.Data.ShouldBe("result");
+        }
+
+        [Fact]
+        public void Failed_ShouldRetrieveAllErrors()
+        {
+            // Act
+            var sr = ServiceResult.Failed("error 1", "error 2");
+
+            // Assert
+            Assert.Collection(sr.Errors,
+                x => x.ShouldBe("error 1"),
+                x => x.ShouldBe("error 2")
             );
         }
     }

--- a/test/Spk.Common.Tests.Helpers/Service/ServiceResultTests.cs
+++ b/test/Spk.Common.Tests.Helpers/Service/ServiceResultTests.cs
@@ -218,7 +218,7 @@ namespace Spk.Common.Tests.Helpers.Service
             // Act
             var result = ServiceResult<string>.Succeed("result");
 
-            // Act && assert
+            // Assert
             result.Success.ShouldBeTrue();
             result.Data.ShouldBe("result");
         }


### PR DESCRIPTION
This PR brings a static API to our `ServiceResult` class. Instead of doing this:
```
public ServiceResult<int> GetResult()
{
    var result = new ServiceResult<int>();

    var serviceCall = _service.ExecuteAsync();
    if (serviceCall == null)
    {
        result.AddError("Service error");
    }
    else
    {
        result.SetData(serviceCall.Int);
    }

    return result;
}
```

We will be able to use `ServiceResult` class like this:
```
public ServiceResult<int> GetResultWithStaticAPI()
{
    var serviceCall = _service.ExecuteAsync();
    return serviceCall == null
        ? ServiceResult<int>.Failed("Service error")
        : ServiceResult<int>.Succeed(serviceCall.Int);
}
```